### PR TITLE
Revamp UI and add advanced animation controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # WeirdM
 WeirdM lets you create those weird WebM videos that resize as they play, from simple effects that work with any video to advanced custom animations you can create yourself.
 
+## Highlights
+
+* **Multiple animation modes** – Choose between bounce, random, smart trim, or the brand new timeline editor for frame-perfect control.
+* **Keyframe timeline** – Add as many keyframes as you like, pick easing curves, and WeirdM will smoothly interpolate the size changes for you.
+* **Fine-grained controls** – Tweak sine/cosine amplitudes, random ranges, trim fuzziness, output quality (CRF) and frame rate, plus audio passthrough.
+* **Modern interface** – A reorganized layout keeps information and controls easy to find on both desktop and mobile.
+
+Everything runs locally in your browser using FFmpeg and ImageMagick compiled to WebAssembly, so your source video never leaves your machine.
+
 You can use WeirdM online at **https://rebane2001.com/weirdm/**.
 
 ## Guide

--- a/app.css
+++ b/app.css
@@ -1,34 +1,357 @@
+:root {
+    color-scheme: dark;
+    --background: #1f2125;
+    --panel: #2b2e35;
+    --panel-alt: #25272c;
+    --text: #ffffff;
+    --text-muted: #b8bcc7;
+    --accent: #00aff4;
+    --accent-strong: #2d7d46;
+    --border: rgba(255, 255, 255, 0.08);
+    --card-radius: 14px;
+    --transition: 160ms ease;
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
 html {
-    font-family: sans-serif;
-    background-color: #36393F;
-    text-align: center;
-    color: #FFF;
+    background: radial-gradient(circle at top, rgba(0, 175, 244, 0.25), transparent 60%), var(--background);
+    color: var(--text);
+    min-height: 100%;
 }
 
-.container {
-    max-width: 500px;
-    margin: auto;
-}
-
-.flex {
-    height: 100%;
+body {
+    margin: 0;
+    min-height: 100vh;
     display: flex;
+    flex-direction: column;
+    gap: 2rem;
     align-items: center;
-    justify-content: center;
 }
 
-a,a:visited {
-    color: #00AFF4
+a, a:visited {
+    color: var(--accent);
+}
+
+.site-title {
+    margin: 2.5rem 0 0.5rem;
+    font-size: clamp(2.2rem, 4vw, 3rem);
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.layout {
+    width: 100%;
+    max-width: 1100px;
+    padding: 0 1.5rem 4rem;
+    box-sizing: border-box;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.75rem;
+}
+
+.panel {
+    background: var(--panel);
+    border-radius: var(--card-radius);
+    border: 1px solid var(--border);
+    padding: 2rem;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    box-shadow: 0 22px 45px rgba(0, 0, 0, 0.32);
+}
+
+.panel-info {
+    position: relative;
+    overflow: hidden;
+}
+
+.panel-info::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at top right, rgba(0, 175, 244, 0.15), transparent 60%);
+}
+
+.panel-controls {
+    background: var(--panel-alt);
+}
+
+.controls {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.card {
+    border-radius: calc(var(--card-radius) - 4px);
+    border: 1px solid var(--border);
+    background: rgba(15, 17, 20, 0.35);
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.card h2 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.card-description {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.mode-list {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.mode-option {
+    border-radius: 12px;
+    border: 1px solid var(--border);
+    padding: 0.75rem 0.9rem;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.75rem;
+    align-items: center;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.02);
+    transition: border-color var(--transition), background var(--transition), transform var(--transition);
+}
+
+.mode-option:hover,
+.mode-option:focus-within {
+    border-color: rgba(0, 175, 244, 0.6);
+    background: rgba(0, 175, 244, 0.08);
+    transform: translateY(-1px);
+}
+
+.mode-option input[type="radio"] {
+    accent-color: var(--accent);
+    width: 18px;
+    height: 18px;
+}
+
+.mode-title {
+    font-weight: 600;
+}
+
+.mode-desc {
+    display: block;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.mode-options {
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 1.25rem 1.1rem;
+    background: rgba(0, 0, 0, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.mode-options[hidden] {
+    display: none;
+}
+
+.options-grid {
+    display: grid;
+    gap: 1.1rem;
+    grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.options-grid.single {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.axis-group {
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 1rem;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.axis-group legend {
+    font-weight: 600;
+    padding: 0 0.5rem;
+}
+
+.field,
+.toggle {
+    display: grid;
+    gap: 0.4rem;
+    font-size: 0.9rem;
+}
+
+.field span,
+.toggle span {
+    color: var(--text-muted);
+}
+
+.field input,
+.field select {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0.45rem 0.5rem;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text);
+    transition: border-color var(--transition), background var(--transition);
+}
+
+.field input:focus,
+.field select:focus {
+    outline: none;
+    border-color: rgba(0, 175, 244, 0.7);
+    background: rgba(0, 175, 244, 0.12);
+}
+
+.toggle input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--accent);
 }
 
 .button {
-    min-height: 32px;
-    min-width: 32px;
+    min-height: 40px;
+    min-width: 120px;
     border: none;
-    border-radius: 3px;
+    border-radius: 10px;
     color: #fff;
-    background-color: #4f545c;
-    font-size: 14px;
-    padding: 2px 16px;
+    background: linear-gradient(135deg, #1c92d2, #2d7d46);
+    font-size: 0.95rem;
+    font-weight: 600;
+    padding: 0.6rem 1.25rem;
     cursor: pointer;
+    transition: transform var(--transition), filter var(--transition);
+    text-decoration: none;
+    text-align: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.button:hover {
+    transform: translateY(-1px);
+    filter: brightness(1.05);
+}
+
+.button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    filter: none;
+}
+
+.button.secondary {
+    background: linear-gradient(135deg, rgba(0, 175, 244, 0.6), rgba(0, 175, 244, 0.35));
+}
+
+.button.subtle {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-muted);
+    min-width: 0;
+    padding-inline: 0.9rem;
+}
+
+.file-input {
+    width: 100%;
+    padding: 0.8rem;
+    border-radius: 12px;
+    border: 1px dashed rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text);
+    box-sizing: border-box;
+}
+
+.file-input:hover {
+    border-color: rgba(0, 175, 244, 0.6);
+}
+
+.resource-card {
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    padding: 1.2rem;
+    background: rgba(0, 175, 244, 0.05);
+    display: grid;
+    gap: 0.75rem;
+}
+
+.timeline-table-wrapper {
+    overflow-x: auto;
+}
+
+.timeline-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: rgba(15, 17, 20, 0.45);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.timeline-table th,
+.timeline-table td {
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 0.9rem;
+}
+
+.timeline-table th {
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.timeline-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.timeline-table input,
+.timeline-table select {
+    width: 100%;
+    padding: 0.35rem 0.4rem;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(0, 0, 0, 0.25);
+    color: var(--text);
+}
+
+.timeline-table button {
+    min-width: 0;
+    padding: 0.35rem 0.6rem;
+    font-size: 0.8rem;
+    border-radius: 8px;
+}
+
+.timeline-row-locked button {
+    visibility: hidden;
+}
+
+.timeline-actions {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+@media (max-width: 720px) {
+    .layout {
+        padding-inline: 1rem;
+    }
+
+    .panel {
+        padding: 1.5rem;
+    }
+
+    .card {
+        padding: 1.25rem;
+    }
 }

--- a/app.js
+++ b/app.js
@@ -4,26 +4,32 @@
 const { createFFmpeg } = FFmpeg;
 
 let ffmpeg = createFFmpeg({ log: true });
+let detectedFps = "15";
 let fps = "15";
 let crf = "42";
-let mode = "trim";
+let mode = "bounce";
 
 const filePicker = document.getElementById("filepicker");
 const startBtn = document.querySelector(".button.start");
+const timelineBody = document.getElementById("timeline-rows");
 
 const setProgress = (percentage) => {
     if (percentage >= 0) {
-        startBtn.innerText = `Processing (${percentage}%)...`;
-        startBtn.style.background = `linear-gradient(to right, #2d7d46 ${percentage - 1}%, #4f545c ${percentage}%, #4f545c)`;
+        const pct = Math.min(100, Math.max(0, percentage));
+        startBtn.innerText = `Processing ${pct}%`;
+        startBtn.style.background = `linear-gradient(90deg, rgba(0, 175, 244, 0.85) ${pct}%, rgba(45, 125, 70, 0.4) ${pct}%)`;
     } else {
-        startBtn.style.background = null;
+        startBtn.innerText = "Create WebM";
+        startBtn.style.background = "";
     }
-}
+};
 
 const recycleFFmpeg = async () => {
-    let files = [];
-    files.push(['input.avi', ffmpeg.FS('readFile', 'input.avi')]);
-    ffmpeg.FS('unlink', 'input.avi')
+    const files = [];
+    try {
+        files.push(['input.avi', ffmpeg.FS('readFile', 'input.avi')]);
+        ffmpeg.FS('unlink', 'input.avi');
+    } catch {}
     let i = 0;
     while (true) {
         i++;
@@ -51,9 +57,9 @@ const recycleFFmpeg = async () => {
     } catch {}
     ffmpeg = createFFmpeg({ log: true });
     if (!ffmpeg.isLoaded()) await ffmpeg.load();
-    for (i = 0; i < files.length; ++i) {
-        ffmpeg.FS('writeFile', files[i][0], files[i][1]);
-        files[i][1] = null;
+    for (let j = 0; j < files.length; j++) {
+        ffmpeg.FS('writeFile', files[j][0], files[j][1]);
+        files[j][1] = null;
     }
 };
 
@@ -64,91 +70,408 @@ const makeWebmPart = async (inArgs, webmCount) => {
     });
     ffmpeg.FS('writeFile', 'concat.txt', Uint8Array.from(concat.split('').map(letter => letter.charCodeAt(0))));
     await ffmpeg.run('-y', '-f', 'concat', '-i', 'concat.txt', '-vf', `settb=AVTB,setpts=N/${fps}/TB,fps=${fps}`, '-pix_fmt', 'yuv420p', '-crf', crf, '-r', fps, webmCount + '.webm');
-    /*
-    inArgs.forEach((arg) => {
-        ffmpeg.FS('unlink', arg);
-    });
-     */
-    // Wipe worker processes every 10 webms to prevent OOM
     if (webmCount % 10 === 0) await recycleFFmpeg();
 };
 
-function getRandomResize(frame) {
-    if (frame === 1) return "100%x100%";
-    const doH = document.getElementById("random-h").checked;
-    const doV = document.getElementById("random-v").checked;
-    return `${doH ? Math.ceil(Math.random()*100) : 100}%x${doV ? Math.ceil(Math.random()*100) : 100}%`;
-}
+const clampNumber = (value, min, max, fallback) => {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return fallback;
+    return Math.min(max, Math.max(min, parsed));
+};
 
-function getBounceResize(frame) {
-    if (frame === 1) return "100%x100%";
-    const funcs = {
-        none: (s) => 100,
-        sin: (s) => Math.ceil((Math.sin(frame*s/Number(fps))+1)*50),
-        cos: (s) => Math.ceil((Math.cos(frame*s/Number(fps))+1)*50),
+const sanitizeRange = (minValue, maxValue, fallbackMin, fallbackMax) => {
+    let min = clampNumber(minValue, 1, 400, fallbackMin);
+    let max = clampNumber(maxValue, 1, 400, fallbackMax);
+    if (min > max) {
+        [min, max] = [max, min];
+    }
+    return { min, max };
+};
+
+const easingFunctions = {
+    linear: (t) => t,
+    easeIn: (t) => t * t,
+    easeOut: (t) => 1 - Math.pow(1 - t, 2),
+    easeInOut: (t) => (t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2),
+};
+
+const modes = ["bounce", "random", "timeline", "trim"];
+
+const updateModeVisibility = () => {
+    modes.forEach((m) => {
+        const container = document.getElementById(`${m}-options`);
+        if (!container) return;
+        const radio = document.getElementById(m);
+        container.hidden = !radio.checked;
+    });
+};
+
+document.querySelectorAll('input[name="mode"]').forEach((input) => {
+    input.addEventListener('change', () => {
+        mode = input.value;
+        updateModeVisibility();
+    });
+});
+
+const updateBounceFieldState = () => {
+    ['h', 'v'].forEach((axis) => {
+        const style = document.getElementById(`bounce-${axis}-style`).value;
+        const staticInput = document.getElementById(`bounce-${axis}-static`);
+        const minInput = document.getElementById(`bounce-${axis}-min`);
+        const maxInput = document.getElementById(`bounce-${axis}-max`);
+        const isStatic = style === 'none';
+        staticInput.disabled = !isStatic;
+        minInput.disabled = isStatic;
+        maxInput.disabled = isStatic;
+    });
+};
+
+document.querySelectorAll('#bounce-h-style, #bounce-v-style').forEach((select) => {
+    select.addEventListener('change', updateBounceFieldState);
+});
+
+const updateRandomFieldState = () => {
+    ['h', 'v'].forEach((axis) => {
+        const enabled = document.getElementById(`random-${axis}`).checked;
+        document.getElementById(`random-${axis}-min`).disabled = !enabled;
+        document.getElementById(`random-${axis}-max`).disabled = !enabled;
+    });
+};
+
+document.querySelectorAll('#random-h, #random-v').forEach((checkbox) => {
+    checkbox.addEventListener('change', updateRandomFieldState);
+});
+
+const createTimelineRow = ({ time, width, height, easing, lockTime = false, lockRemove = false, disableEasing = false }) => {
+    const row = document.createElement('tr');
+    if (lockRemove) {
+        row.classList.add('timeline-row-locked');
+    }
+    const timeCell = document.createElement('td');
+    const timeInput = document.createElement('input');
+    timeInput.type = 'number';
+    timeInput.className = 'timeline-time';
+    timeInput.min = '0';
+    timeInput.max = '100';
+    timeInput.value = time;
+    if (lockTime) {
+        timeInput.disabled = true;
+    }
+    timeCell.appendChild(timeInput);
+
+    const widthCell = document.createElement('td');
+    const widthInput = document.createElement('input');
+    widthInput.type = 'number';
+    widthInput.className = 'timeline-width';
+    widthInput.min = '1';
+    widthInput.max = '400';
+    widthInput.value = width;
+    widthCell.appendChild(widthInput);
+
+    const heightCell = document.createElement('td');
+    const heightInput = document.createElement('input');
+    heightInput.type = 'number';
+    heightInput.className = 'timeline-height';
+    heightInput.min = '1';
+    heightInput.max = '400';
+    heightInput.value = height;
+    heightCell.appendChild(heightInput);
+
+    const easingCell = document.createElement('td');
+    const easingSelect = document.createElement('select');
+    easingSelect.className = 'timeline-ease';
+    ['linear', 'easeIn', 'easeOut', 'easeInOut'].forEach((key) => {
+        const option = document.createElement('option');
+        option.value = key;
+        option.textContent = {
+            linear: 'Linear',
+            easeIn: 'Ease in',
+            easeOut: 'Ease out',
+            easeInOut: 'Ease in/out',
+        }[key];
+        if (key === easing) option.selected = true;
+        easingSelect.appendChild(option);
+    });
+    if (disableEasing) easingSelect.disabled = true;
+    easingCell.appendChild(easingSelect);
+
+    const actionsCell = document.createElement('td');
+    if (!lockRemove) {
+        const removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.className = 'button subtle remove-keyframe';
+        removeButton.textContent = 'Remove';
+        removeButton.addEventListener('click', () => {
+            timelineBody.removeChild(row);
+        });
+        actionsCell.appendChild(removeButton);
+    }
+
+    row.appendChild(timeCell);
+    row.appendChild(widthCell);
+    row.appendChild(heightCell);
+    row.appendChild(easingCell);
+    row.appendChild(actionsCell);
+    return row;
+};
+
+const initializeTimeline = () => {
+    timelineBody.innerHTML = '';
+    timelineBody.appendChild(createTimelineRow({ time: 0, width: 100, height: 100, easing: 'linear', lockTime: true, lockRemove: true, disableEasing: true }));
+    timelineBody.appendChild(createTimelineRow({ time: 100, width: 100, height: 100, easing: 'linear', lockTime: true, lockRemove: true }));
+};
+
+const addTimelineRow = () => {
+    const rows = timelineBody.querySelectorAll('tr');
+    const lastRow = rows[rows.length - 1];
+    const beforeLastRow = rows[rows.length - 2];
+    let defaultTime = 50;
+    if (beforeLastRow && lastRow) {
+        const prev = Number(beforeLastRow.querySelector('.timeline-time').value);
+        const next = Number(lastRow.querySelector('.timeline-time').value);
+        defaultTime = Math.round(prev + (next - prev) / 2);
+        if (!Number.isFinite(defaultTime)) defaultTime = 50;
+        if (defaultTime <= prev) defaultTime = Math.min(next - 1, prev + 1);
+        if (defaultTime >= next) defaultTime = Math.max(prev + 1, next - 1);
+        defaultTime = clampNumber(defaultTime, prev + 1, next - 1, 50);
+    }
+    const row = createTimelineRow({ time: defaultTime, width: 120, height: 120, easing: 'linear' });
+    timelineBody.insertBefore(row, lastRow || null);
+};
+
+document.getElementById('add-keyframe').addEventListener('click', addTimelineRow);
+document.getElementById('reset-keyframes').addEventListener('click', initializeTimeline);
+
+const getTimelineRows = () => {
+    const rows = [];
+    timelineBody.querySelectorAll('tr').forEach((row) => {
+        const time = clampNumber(row.querySelector('.timeline-time').value, 0, 100, 0);
+        const width = clampNumber(row.querySelector('.timeline-width').value, 1, 400, 100);
+        const height = clampNumber(row.querySelector('.timeline-height').value, 1, 400, 100);
+        const easing = row.querySelector('.timeline-ease')?.value || 'linear';
+        rows.push({ time, width, height, easing });
+    });
+    rows.sort((a, b) => a.time - b.time);
+    const deduped = [];
+    rows.forEach((entry) => {
+        if (!deduped.length || entry.time !== deduped[deduped.length - 1].time) {
+            deduped.push(entry);
+        } else {
+            deduped[deduped.length - 1] = entry;
+        }
+    });
+    return deduped;
+};
+
+const validateTimelineKeyframes = (keyframes) => {
+    if (keyframes.length < 2) {
+        return { ok: false, message: 'Add at least two keyframes (0% and 100%).' };
+    }
+    const first = keyframes[0];
+    const last = keyframes[keyframes.length - 1];
+    if (first.time !== 0 || last.time !== 100) {
+        return { ok: false, message: 'Ensure the first keyframe is at 0% and the last at 100%.' };
+    }
+    return { ok: true };
+};
+
+const readBounceSettings = () => {
+    const readAxis = (axis) => {
+        const style = document.getElementById(`bounce-${axis}-style`).value;
+        const speed = clampNumber(document.getElementById(`bounce-${axis}-speed`).value, 1, 200, 10);
+        const staticSize = clampNumber(document.getElementById(`bounce-${axis}-static`).value, 1, 400, 100);
+        const range = sanitizeRange(document.getElementById(`bounce-${axis}-min`).value, document.getElementById(`bounce-${axis}-max`).value, 70, 130);
+        return { style, speed, staticSize, min: range.min, max: range.max };
     };
-    let h = funcs[document.getElementById("bounce-h-style").value](document.getElementById("bounce-h-speed").value);
-    let v = funcs[document.getElementById("bounce-v-style").value](document.getElementById("bounce-v-speed").value);
-    return `${h}%x${v}%`;
-}
+    return {
+        horizontal: readAxis('h'),
+        vertical: readAxis('v'),
+    };
+};
 
-const makeVideo = async (file) => {
+const readRandomSettings = () => {
+    const readAxis = (axis) => {
+        const enabled = document.getElementById(`random-${axis}`).checked;
+        const range = sanitizeRange(document.getElementById(`random-${axis}-min`).value, document.getElementById(`random-${axis}-max`).value, 60, 140);
+        return { enabled, min: range.min, max: range.max };
+    };
+    return {
+        horizontal: readAxis('h'),
+        vertical: readAxis('v'),
+    };
+};
+
+const readTrimSettings = () => ({
+    fuzz: clampNumber(document.getElementById('trim-fuzz').value, 0, 100, 3),
+    padding: clampNumber(document.getElementById('trim-padding').value, 0, 50, 1),
+});
+
+const createResizeArgs = (size) => [
+    'convert',
+    'in.png',
+    '-resize',
+    size,
+    '-set',
+    'filename:mysize',
+    '%wx%h',
+    '%[filename:mysize]',
+];
+
+const createTrimArgs = (settings) => {
+    const args = ['convert', 'in.png'];
+    if (settings.fuzz > 0) {
+        args.push('-fuzz', `${settings.fuzz}%`);
+    }
+    args.push('-trim');
+    if (settings.padding > 0) {
+        const pad = `${settings.padding}x${settings.padding}`;
+        args.push('-shave', pad);
+    }
+    args.push('+repage', '-set', 'filename:mysize', '%wx%h', '%[filename:mysize]');
+    return args;
+};
+
+const computeBounceValue = (frame, fpsValue, axisSettings) => {
+    if (axisSettings.style === 'none') {
+        return Math.round(axisSettings.staticSize);
+    }
+    const { min, max, speed, style } = axisSettings;
+    const low = Math.min(min, max);
+    const high = Math.max(min, max);
+    const amplitude = (high - low) / 2;
+    const center = low + amplitude;
+    const trig = style === 'sin' ? Math.sin : Math.cos;
+    const t = (frame * speed) / Number(fpsValue || 1);
+    const value = center + trig(t) * amplitude;
+    return Math.round(Math.max(1, value));
+};
+
+const getBounceResize = (frame, fpsValue, settings) => {
+    const horizontal = computeBounceValue(frame, fpsValue, settings.horizontal);
+    const vertical = computeBounceValue(frame, fpsValue, settings.vertical);
+    return `${horizontal}%x${vertical}%`;
+};
+
+const randomBetween = (min, max) => Math.round(min + Math.random() * (max - min));
+
+const getRandomResize = (settings) => {
+    const width = settings.horizontal.enabled ? randomBetween(settings.horizontal.min, settings.horizontal.max) : 100;
+    const height = settings.vertical.enabled ? randomBetween(settings.vertical.min, settings.vertical.max) : 100;
+    return `${width}%x${height}%`;
+};
+
+const getTimelineResize = (frame, framesTotal, keyframes) => {
+    if (!keyframes.length) return '100%x100%';
+    if (keyframes.length === 1) {
+        const only = keyframes[0];
+        return `${only.width}%x${only.height}%`;
+    }
+    const total = Math.max(1, framesTotal - 1);
+    const progressPercent = ((frame - 1) / total) * 100;
+    let previous = keyframes[0];
+    for (let i = 1; i < keyframes.length; i++) {
+        const current = keyframes[i];
+        if (progressPercent <= current.time || i === keyframes.length - 1) {
+            const span = current.time - previous.time;
+            const spanSafe = span <= 0 ? 1 : span;
+            const local = (progressPercent - previous.time) / spanSafe;
+            const eased = easingFunctions[current.easing]?.(Math.min(1, Math.max(0, local))) ?? easingFunctions.linear(Math.min(1, Math.max(0, local)));
+            const width = Math.round(previous.width + (current.width - previous.width) * eased);
+            const height = Math.round(previous.height + (current.height - previous.height) * eased);
+            return `${width}%x${height}%`;
+        }
+        previous = current;
+    }
+    const last = keyframes[keyframes.length - 1];
+    return `${last.width}%x${last.height}%`;
+};
+
+const gatherSettings = () => {
+    const selectedMode = modes.find((m) => document.getElementById(m)?.checked) || 'bounce';
+    const crfValue = clampNumber(document.getElementById('crf').value, 0, 63, 42);
+    const fpsValueRaw = document.getElementById('output-fps').value;
+    const fpsOverride = fpsValueRaw ? clampNumber(fpsValueRaw, 1, 240, null) : null;
+    const includeAudio = document.getElementById('include-audio').checked;
+
+    const settings = { mode: selectedMode, crf: crfValue.toString(), includeAudio };
+    if (fpsOverride) settings.fpsOverride = fpsOverride.toString();
+
+    if (selectedMode === 'bounce') settings.bounce = readBounceSettings();
+    if (selectedMode === 'random') settings.random = readRandomSettings();
+    if (selectedMode === 'trim') settings.trim = readTrimSettings();
+    if (selectedMode === 'timeline') settings.timeline = getTimelineRows();
+
+    return settings;
+};
+
+const makeVideo = async (file, options) => {
     setProgress(0);
     if (!ffmpeg.isLoaded()) await ffmpeg.load();
     setProgress(5);
     ffmpeg.FS('writeFile', 'input.avi', file);
 
+    detectedFps = '15';
     ffmpeg.setLogger(({ type, message }) => {
-        if (type === "fferr" && message.includes(" fps")) {
-            fps = message.split(" fps")[0].split(" ").pop();
+        if (type === 'fferr' && message.includes(' fps')) {
+            const parts = message.split(' fps')[0].trim().split(' ');
+            detectedFps = parts.pop();
         }
     });
-    await ffmpeg.run('-y', '-i', 'input.avi')
-    console.log("Frame rate is " + fps);
-    ffmpeg.setLogger(({ type, message }) => {});
+    await ffmpeg.run('-y', '-i', 'input.avi');
+    ffmpeg.setLogger(() => {});
+
+    fps = options.fpsOverride || detectedFps || '15';
+    crf = options.crf || '42';
+
     await ffmpeg.run('-y', '-i', 'input.avi', '%06d.png');
     setProgress(10);
+
     let framesTotal = 0;
     while (true) {
         framesTotal++;
         const fn = framesTotal.toString().padStart(6, '0') + '.png';
-        let file;
         try {
-            file = ffmpeg.FS('readFile', fn);
+            ffmpeg.FS('readFile', fn);
         } catch {
             break;
         }
     }
 
+    const timelineKeyframes = options.mode === 'timeline' ? options.timeline : [];
     let lastRes;
     let webmCount = 0;
     let inArgs = [];
     for (let frame = 1; frame < framesTotal; frame++) {
         const fn = frame.toString().padStart(6, '0') + '.png';
-        const file = ffmpeg.FS('readFile', fn);
-
-        const args = {
-            trim: ["convert", "in.png", "-trim", "-shave", "1x1", "+repage", "-set", "filename:mysize", "%wx%h", "%[filename:mysize]"],
-            bounce: ["convert", "in.png", "-resize", getBounceResize(frame), "-set", "filename:mysize", "%wx%h", "%[filename:mysize]"],
-            random: ["convert", "in.png", "-resize", getRandomResize(frame), "-set", "filename:mysize", "%wx%h", "%[filename:mysize]"],
-        }[mode];
-        const out = await Magick.Call([{ 'name': 'in.png', 'content': file }], args);
+        const png = ffmpeg.FS('readFile', fn);
+        let args;
+        if (options.mode === 'trim') {
+            args = createTrimArgs(options.trim || readTrimSettings());
+        } else {
+            const size = {
+                bounce: () => getBounceResize(frame, Number(fps), options.bounce || readBounceSettings()),
+                random: () => getRandomResize(options.random || readRandomSettings()),
+                timeline: () => getTimelineResize(frame, framesTotal, timelineKeyframes || []),
+            }[options.mode]?.() || '100%x100%';
+            args = createResizeArgs(size);
+        }
+        const out = await Magick.Call([{ name: 'in.png', content: png }], args);
         const res = out[0].name;
         ffmpeg.FS('writeFile', fn, out[0].buffer);
         if (!lastRes) lastRes = res;
         if (lastRes !== res) {
-            // TODO: Make multi-threaded
             await makeWebmPart(inArgs, webmCount);
             webmCount++;
             lastRes = res;
             inArgs = [];
         }
-        setProgress(10 + Math.floor(frame/framesTotal*80));
+        setProgress(10 + Math.floor((frame / Math.max(1, framesTotal - 1)) * 80));
         inArgs.push(fn);
     }
     await makeWebmPart(inArgs, webmCount);
     webmCount++;
     setProgress(90);
+
     let concat = "";
     for (let i = 0; i < webmCount; i++) {
         concat += `file ${i}.webm\n`;
@@ -156,67 +479,75 @@ const makeVideo = async (file) => {
     ffmpeg.FS('writeFile', 'concat.txt', Uint8Array.from(concat.split('').map(letter => letter.charCodeAt(0))));
     await ffmpeg.run('-y', '-f', 'concat', '-safe', '0', '-i', 'concat.txt', '-c', 'copy', 'vid.webm');
     setProgress(95);
-    await ffmpeg.run('-y', '-i', 'vid.webm', '-i', 'input.avi', '-c:v', 'copy', '-map', '0:v', '-map', '1:a?', '-metadata', 'title=WeirdM', 'out.webm');
+    const finalArgs = ['-y', '-i', 'vid.webm', '-i', 'input.avi', '-c:v', 'copy', '-map', '0:v'];
+    if (options.includeAudio) {
+        finalArgs.push('-map', '1:a?');
+    }
+    finalArgs.push('-metadata', 'title=WeirdM', 'out.webm');
+    await ffmpeg.run(...finalArgs);
     setProgress(100);
     return ffmpeg.FS('readFile', 'out.webm');
-
 };
 
-const modes = ["bounce", "random", "trim"];
-const getMode = () => {
-    for (let m of modes) {
-        if (document.getElementById(m).checked) return m;
-    }
-    return "err";
-}
+const downloadURL = (data, fileName) => {
+    const a = document.createElement('a');
+    a.href = data;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.style.display = 'none';
+    a.click();
+    a.remove();
+};
 
-// Yes, it's a weird way of doing this, but radio buttons suck
-document.onclick = () => {
-    for (let m of modes) {
-        document.getElementById(`${m}-options`).style.display = document.getElementById(m).checked ? "block" : "none";
-    }
-}
+const downloadBlob = (data, fileName, mimeType) => {
+    const blob = new Blob([data], { type: mimeType });
+    const url = window.URL.createObjectURL(blob);
+    downloadURL(url, fileName);
+    setTimeout(() => window.URL.revokeObjectURL(url), 1000);
+};
 
-startBtn.onclick = () => {
-    if (!filePicker.files) return alert("Pick a file first!");
+startBtn.addEventListener('click', () => {
+    if (!filePicker.files || !filePicker.files.length) {
+        alert('Pick a file first!');
+        return;
+    }
+    const settings = gatherSettings();
+    if (settings.mode === 'timeline') {
+        const validation = validateTimelineKeyframes(settings.timeline || []);
+        if (!validation.ok) {
+            alert(validation.message);
+            return;
+        }
+    }
+
     const reader = new FileReader();
     const filename = filePicker.files[0].name.replace(/\.[^/.]+$/, "_weirdm.webm");
-    reader.onload = function() {
+    reader.onload = function () {
         const array = new Uint8Array(this.result);
-        mode = getMode();
-        crf = document.getElementById("crf").value;
-        makeVideo(array).then((final) => {
-            downloadBlob(final, filename);
+        mode = settings.mode;
+        crf = settings.crf;
+        setProgress(0);
+        makeVideo(array, settings).then((final) => {
+            downloadBlob(final, filename, 'video/webm');
             startBtn.disabled = false;
-            startBtn.innerText = "Go!";
             setProgress(-1);
             try {
                 ffmpeg.exit();
             } catch {}
+        }).catch((err) => {
+            console.error(err);
+            alert('Something went wrong while creating the WebM. Check the console for details.');
+            startBtn.disabled = false;
+            setProgress(-1);
         });
-    }
+    };
     reader.readAsArrayBuffer(filePicker.files[0]);
     startBtn.disabled = true;
-    startBtn.innerText = "Processing...";
-}
+    startBtn.innerText = 'Preparing…';
+    startBtn.style.background = '';
+});
 
-// https://stackoverflow.com/a/62176999/2251833
-const downloadURL = (data, fileName) => {
-    const a = document.createElement('a')
-    a.href = data
-    a.download = fileName
-    document.body.appendChild(a)
-    a.style.display = 'none'
-    a.click()
-    a.remove()
-}
-
-const downloadBlob = (data, fileName, mimeType) => {
-    const blob = new Blob([data], {
-        type: mimeType
-    })
-    const url = window.URL.createObjectURL(blob)
-    downloadURL(url, fileName)
-    setTimeout(() => window.URL.revokeObjectURL(url), 1000)
-}
-
+initializeTimeline();
+updateModeVisibility();
+updateBounceFieldState();
+updateRandomFieldState();

--- a/index.html
+++ b/index.html
@@ -13,59 +13,224 @@
     <meta charset="UTF-8">
 </head>
 <body>
-<h1>WeirdM</h1>
-<div class="container">
-    <h3>About</h3>
-    <p>WeirdM lets you create those weird WebM videos that resize as they play, from simple effects that work with
-        any video to advanced custom animations you can create yourself.</p>
-    <p>The processing happens locally in your browser, so your videos do not get sent to my server.
-        The source code is available on <a href="https://github.com/rebane2001/weirdm">GitHub</a>.</p>
-    <h3>Guide</h3>
-    <p>A video tutorial is available <a href="https://www.youtube.com/watch?v=Wf2filWCcJo">here</a>.</p>
-    <h3>Options</h3>
-    <input type="radio" id="bounce" name="mode" checked>
-    <label for="bounce">Bounce (simple)</label><br>
-    <input type="radio" id="random" name="mode">
-    <label for="random">Random (simple)</label><br>
-    <input type="radio" id="trim" name="mode">
-    <label for="trim">Trim (advanced)</label><br>
-    <br>
-    <div id="bounce-options">
-        <b>Horizontal</b><br>
-        <label for="bounce-h-style">Style:</label>
-        <select id="bounce-h-style">
-            <option value="sin">Sin</option>
-            <option value="cos">Cos</option>
-            <option value="none" selected="selected">None</option>
-        </select><br>
-        <label for="bounce-h-speed">Speed:</label>
-        <input id="bounce-h-speed" type="number" min="1" max="50" value="10"><br>
-        <br>
-        <b>Vertical</b><br>
-        <label for="bounce-v-style">Style:</label>
-        <select id="bounce-v-style">
-            <option value="sin" selected="selected">Sin</option>
-            <option value="cos">Cos</option>
-            <option value="none">None</option>
-        </select><br>
-        <label for="bounce-v-speed">Speed:</label>
-        <input id="bounce-v-speed" type="number" min="1" max="50" value="10"><br>
-    </div>
-    <div id="random-options" style="display: none">
-        <input type="checkbox" id="random-h" checked>
-        <label for="random-h">Horizontal</label><br>
-        <input type="checkbox" id="random-v" checked>
-        <label for="random-v">Vertical</label><br>
-    </div>
-    <div id="trim-options" style="display: none">
-        <p>Trim removes a solid color or transparency from all 4 borders of your video. Please check out the guide for more info.</p>
-    </div>
-    <br><label for="crf">CRF (quality, lower is better):</label>
-    <input id="crf" type="number" min="0" max="63" value="42"><br>
-    <h3>Pick a file</h3>
-    <input type="file" id="filepicker"/><br><br>
-    <button class="button start">Go!</button>
-</div>
+<h1 class="site-title">WeirdM</h1>
+<main class="layout">
+    <section class="panel panel-info">
+        <h2>What is WeirdM?</h2>
+        <p>WeirdM lets you create those weird WebM videos that resize as they play, from simple effects that work with any
+            video to fully custom animations that you control keyframe by keyframe.</p>
+        <p>Everything is processed locally in your browser&mdash;your video never leaves your device. The source code is
+            available on <a href="https://github.com/rebane2001/weirdm">GitHub</a>.</p>
+        <div class="resource-card">
+            <h3>Need a walkthrough?</h3>
+            <p>Watch the community-made tutorial for a complete introduction.</p>
+            <a class="button secondary" href="https://www.youtube.com/watch?v=Wf2filWCcJo" target="_blank"
+               rel="noopener">Watch the video guide</a>
+        </div>
+    </section>
+    <section class="panel panel-controls">
+        <form class="controls" id="controls-form" autocomplete="off">
+            <section class="card">
+                <h2>1. Pick an animation style</h2>
+                <p class="card-description">Choose how WeirdM should resize your video. Each style exposes detailed
+                    controls below.</p>
+                <div class="mode-list">
+                    <label class="mode-option">
+                        <input type="radio" id="bounce" name="mode" value="bounce" checked>
+                        <div>
+                            <span class="mode-title">Bounce</span>
+                            <span class="mode-desc">Oscillate the frame using sine or cosine waves.</span>
+                        </div>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" id="random" name="mode" value="random">
+                        <div>
+                            <span class="mode-title">Random</span>
+                            <span class="mode-desc">Jump to random sizes within your chosen range.</span>
+                        </div>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" id="timeline" name="mode" value="timeline">
+                        <div>
+                            <span class="mode-title">Timeline</span>
+                            <span class="mode-desc">Design a keyframe timeline for complete control.</span>
+                        </div>
+                    </label>
+                    <label class="mode-option">
+                        <input type="radio" id="trim" name="mode" value="trim">
+                        <div>
+                            <span class="mode-title">Smart trim</span>
+                            <span class="mode-desc">Automatically crop away solid borders or transparency.</span>
+                        </div>
+                    </label>
+                </div>
+
+                <div class="mode-options" id="bounce-options">
+                    <h3>Bounce options</h3>
+                    <div class="options-grid">
+                        <fieldset class="axis-group">
+                            <legend>Horizontal motion</legend>
+                            <label class="field">
+                                <span>Waveform</span>
+                                <select id="bounce-h-style">
+                                    <option value="sin">Sine</option>
+                                    <option value="cos">Cosine</option>
+                                    <option value="none" selected>Static</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Speed</span>
+                                <input id="bounce-h-speed" type="number" min="1" max="80" value="10">
+                            </label>
+                            <label class="field">
+                                <span>Static size (%)</span>
+                                <input id="bounce-h-static" type="number" min="1" max="400" value="100">
+                            </label>
+                            <label class="field">
+                                <span>Minimum size (%)</span>
+                                <input id="bounce-h-min" type="number" min="1" max="400" value="70">
+                            </label>
+                            <label class="field">
+                                <span>Maximum size (%)</span>
+                                <input id="bounce-h-max" type="number" min="1" max="400" value="130">
+                            </label>
+                        </fieldset>
+                        <fieldset class="axis-group">
+                            <legend>Vertical motion</legend>
+                            <label class="field">
+                                <span>Waveform</span>
+                                <select id="bounce-v-style">
+                                    <option value="sin" selected>Sine</option>
+                                    <option value="cos">Cosine</option>
+                                    <option value="none">Static</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Speed</span>
+                                <input id="bounce-v-speed" type="number" min="1" max="80" value="10">
+                            </label>
+                            <label class="field">
+                                <span>Static size (%)</span>
+                                <input id="bounce-v-static" type="number" min="1" max="400" value="100">
+                            </label>
+                            <label class="field">
+                                <span>Minimum size (%)</span>
+                                <input id="bounce-v-min" type="number" min="1" max="400" value="70">
+                            </label>
+                            <label class="field">
+                                <span>Maximum size (%)</span>
+                                <input id="bounce-v-max" type="number" min="1" max="400" value="130">
+                            </label>
+                        </fieldset>
+                    </div>
+                </div>
+
+                <div class="mode-options" id="random-options" hidden>
+                    <h3>Random options</h3>
+                    <div class="options-grid">
+                        <fieldset class="axis-group">
+                            <legend>Horizontal</legend>
+                            <label class="toggle">
+                                <input type="checkbox" id="random-h" checked>
+                                <span>Allow random width changes</span>
+                            </label>
+                            <label class="field">
+                                <span>Minimum size (%)</span>
+                                <input id="random-h-min" type="number" min="1" max="400" value="60">
+                            </label>
+                            <label class="field">
+                                <span>Maximum size (%)</span>
+                                <input id="random-h-max" type="number" min="1" max="400" value="140">
+                            </label>
+                        </fieldset>
+                        <fieldset class="axis-group">
+                            <legend>Vertical</legend>
+                            <label class="toggle">
+                                <input type="checkbox" id="random-v" checked>
+                                <span>Allow random height changes</span>
+                            </label>
+                            <label class="field">
+                                <span>Minimum size (%)</span>
+                                <input id="random-v-min" type="number" min="1" max="400" value="60">
+                            </label>
+                            <label class="field">
+                                <span>Maximum size (%)</span>
+                                <input id="random-v-max" type="number" min="1" max="400" value="140">
+                            </label>
+                        </fieldset>
+                    </div>
+                </div>
+
+                <div class="mode-options" id="timeline-options" hidden>
+                    <h3>Timeline options</h3>
+                    <p>Create keyframes that describe the size of the video at different points in the animation. The
+                        animation will smoothly interpolate between each keyframe.</p>
+                    <div class="timeline-table-wrapper">
+                        <table class="timeline-table">
+                            <thead>
+                            <tr>
+                                <th scope="col">Position (%)</th>
+                                <th scope="col">Width (%)</th>
+                                <th scope="col">Height (%)</th>
+                                <th scope="col">Easing</th>
+                                <th scope="col" aria-label="Actions"></th>
+                            </tr>
+                            </thead>
+                            <tbody id="timeline-rows">
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="timeline-actions">
+                        <button type="button" class="button secondary" id="add-keyframe">Add keyframe</button>
+                        <button type="button" class="button subtle" id="reset-keyframes">Reset timeline</button>
+                    </div>
+                </div>
+
+                <div class="mode-options" id="trim-options" hidden>
+                    <h3>Smart trim options</h3>
+                    <p>Trim removes a solid color or transparent border from every frame. Tweak the fuzziness if your
+                        edges are noisy.</p>
+                    <div class="options-grid single">
+                        <label class="field">
+                            <span>Edge similarity (fuzz %)</span>
+                            <input id="trim-fuzz" type="number" min="0" max="100" value="3">
+                        </label>
+                        <label class="field">
+                            <span>Extra padding (px)</span>
+                            <input id="trim-padding" type="number" min="0" max="50" value="1">
+                        </label>
+                    </div>
+                </div>
+            </section>
+
+            <section class="card">
+                <h2>2. Output settings</h2>
+                <div class="options-grid single">
+                    <label class="field">
+                        <span>CRF (quality, lower is higher quality)</span>
+                        <input id="crf" type="number" min="0" max="63" value="42">
+                    </label>
+                    <label class="field">
+                        <span>Override output FPS</span>
+                        <input id="output-fps" type="number" min="1" max="120" placeholder="Match source">
+                    </label>
+                    <label class="toggle">
+                        <input type="checkbox" id="include-audio" checked>
+                        <span>Copy audio track when available</span>
+                    </label>
+                </div>
+            </section>
+
+            <section class="card">
+                <h2>3. Pick a source video</h2>
+                <p class="card-description">The processing happens on your device. Larger videos can take a while to
+                    render.</p>
+                <input type="file" id="filepicker" accept="video/*" class="file-input">
+                <button type="button" class="button start">Create WebM</button>
+            </section>
+        </form>
+    </section>
+</main>
 <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the WeirdM interface with a modern two-panel layout and clearer control grouping
- add granular settings for bounce/random modes plus a keyframe timeline editor and smarter trim configuration
- introduce output options for CRF, FPS override, audio passthrough, and refresh the README highlights

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cbc0588584832d8de06ba945f2f162